### PR TITLE
Enabled dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: k8s.io/*
+    update-types:
+    - version-update:semver-major
+    - version-update:semver-minor


### PR DESCRIPTION
Daily version updates for actions and go modules. `k8s.io` go modules
will ignore major and minor versions.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>