### PR TITLE
Avoid duplicate push/pr builds from dependabot

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,12 @@
 name: CI
 
 on:
-  push: {}
+  push:
+    branches:
+    - '**'
+    - '!dependabot/**'
+    tags:
+    - '**'
   pull_request: {}
 
 jobs:


### PR DESCRIPTION
Ignore the pushed branch and only run the PR.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>